### PR TITLE
Bug fix when using models with overriding tags

### DIFF
--- a/lib/sdf/xml.rb
+++ b/lib/sdf/xml.rb
@@ -212,19 +212,16 @@ module SDF
                     else
                         raise ArgumentError, "cannot interpret include URI #{uri}"
                     end
-                    replacements << [inc, included_sdf.root.elements]
-                end
-
-                inc.elements.each do |e|
-                    if (e.name != "uri") then
-                        replacements.each do |inc, models|
-                            models.each do |m|
+                    inc.elements.each do |e|
+                        if (e.name != "uri") then
+                            included_sdf.root.elements.each do |m|    
                                 m.elements.to_a(e.name).each(&:remove)
                                 m << e.dup
                             end
                         end
                     end
-               end
+                    replacements << [inc, included_sdf.root.elements]
+                end
             end
                             
             replacements.each do |inc, models|

--- a/test/data/models/model_with_nonid_pose/model.sdf
+++ b/test/data/models/model_with_nonid_pose/model.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdf version="1.5">
-  <model name="simple test model">
+  <model name="model with non ID pose">
       <pose>5 2 1 4 5 3</pose>
   </model>
 </sdf>

--- a/test/data/models/model_with_overriding_tags_in_include/model.sdf
+++ b/test/data/models/model_with_overriding_tags_in_include/model.sdf
@@ -4,4 +4,9 @@
         <uri>model://model_with_nonid_pose</uri>
         <pose>0 0 0 0 0 0</pose>
     </include>
+
+    <include>
+        <uri>model://simple_model</uri>
+        <pose>0 0 -20 0 0 0</pose>
+    </include>
 </sdf>

--- a/test/test_xml.rb
+++ b/test/test_xml.rb
@@ -107,9 +107,16 @@ describe SDF::XML do
         end
         it "replaces tags in the included model by tags present in the include tag" do
             sdf = SDF::XML.load_sdf(File.join(models_dir, "model_with_overriding_tags_in_include", "model.sdf"))
-            model = sdf.elements.enum_for(:each, 'sdf/model/pose').first
+
+            model = sdf.elements.enum_for(:each, 'sdf/model').
+                find { |el| el.attributes['name'] == 'model with non ID pose' }
             # The included model has a non-ID pose
-            assert_equal "0 0 0 0 0 0", model.text
+            assert_equal "0 0 0 0 0 0", model.elements.enum_for(:each, 'pose').first.text
+
+            model = sdf.elements.enum_for(:each, 'sdf/model').
+                find { |el| el.attributes['name'] == 'simple test model' }
+            # The included model has a non-ID pose
+            assert_equal "0 0 -20 0 0 0", model.elements.enum_for(:each, 'pose').first.text
         end
         it "resolves relative paths in <uri> tags" do
             sdf = SDF::XML.load_sdf(File.join(models_dir, "model_with_relative_uris", "model.sdf"))


### PR DESCRIPTION
in add_include_tags the vector replacement was wrongly iterated, causing
it to change the models multiple times.
