### PR TITLE
support recursive SDF models

### DIFF
--- a/lib/sdf.rb
+++ b/lib/sdf.rb
@@ -15,6 +15,7 @@ require 'sdf/axis'
 require 'sdf/axis_limit'
 require 'sdf/plugin'
 require 'sdf/sensor'
+require 'sdf/frame'
 
 # The toplevel namespace for sdf
 #

--- a/lib/sdf.rb
+++ b/lib/sdf.rb
@@ -1,5 +1,6 @@
 require 'geoutm'
 require 'eigen'
+require 'sdf/exceptions'
 require 'sdf/xml'
 require 'sdf/conversions'
 require 'sdf/element'

--- a/lib/sdf/conversions.rb
+++ b/lib/sdf/conversions.rb
@@ -60,6 +60,13 @@ module SDF
             end
         end
 
+        # Converts an Eigen vector into a SDF vector3
+        def self.eigen_to_vector3(v, element_name = "xyz")
+            el = REXML::Element.new(element_name)
+            el.text = "#{v.x} #{v.y} #{v.z}"
+            el
+        end
+
         # Converts a SDF boolean into a Ruby true/false value
         #
         # @param [String,#text] boolean the SDF boolean ('true','false','0',1')

--- a/lib/sdf/element.rb
+++ b/lib/sdf/element.rb
@@ -97,8 +97,24 @@ module SDF
             xpath
         end
 
-        def full_name
-            if (p = parent) && (p_name = p.full_name)
+        # Returns this element's name until the root
+        #
+        # The returned name stops just before the given root, i.e. with an
+        # element whose complete name is
+        #
+        #     el0::el1::el2::element
+        #
+        # then
+        #
+        #     element.full_name(root: el1) # => "el2::element"
+        #
+        # @param [nil,Element] root the root until which the name is built. Use
+        #   nil to stop at the XML root
+        # @return [String]
+        def full_name(root: nil)
+            if root && xml == root.xml
+                nil
+            elsif (p = parent) && (p_name = p.full_name(root: root))
                 p_name + '::' + name
             else
                 name

--- a/lib/sdf/element.rb
+++ b/lib/sdf/element.rb
@@ -61,6 +61,11 @@ module SDF
             xml.attributes['name']
         end
 
+        # Change the element name
+        def name=(name)
+            xml.attributes['name'] = name
+        end
+
         # The XPath from the root this element
         #
         # @return [String]

--- a/lib/sdf/element.rb
+++ b/lib/sdf/element.rb
@@ -94,7 +94,12 @@ module SDF
         end
 
         def to_s
-            xpath
+            s = "#{self.class.name.gsub(/.*::/, '')}[#{name}]"
+            if parent
+                "#{parent}/#{s}"
+            else
+                s
+            end
         end
 
         # Returns this element's name until the root

--- a/lib/sdf/element.rb
+++ b/lib/sdf/element.rb
@@ -102,6 +102,23 @@ module SDF
             end
         end
 
+        # Find a named element within the SDF hierarchy
+        #
+        # @return [Element,nil]
+        def find_by_name(name)
+            xml.elements.each do |element|
+                element_name = element.attributes['name']
+                if name == element_name
+                    return Element.wrap(element, self)
+                elsif name.start_with?("#{element_name}::")
+                    element = Element.wrap(element, self)
+                    suffix  = name[(element_name.size + 2)..-1]
+                    return element.find_by_name(suffix)
+                end
+            end
+            nil
+        end
+
         # Returns this element's name until the root
         #
         # The returned name stops just before the given root, i.e. with an

--- a/lib/sdf/exceptions.rb
+++ b/lib/sdf/exceptions.rb
@@ -1,0 +1,3 @@
+module SDF
+    class InternalError < RuntimeError; end
+end

--- a/lib/sdf/frame.rb
+++ b/lib/sdf/frame.rb
@@ -1,0 +1,12 @@
+module SDF
+    class Frame < Element
+        xml_tag_name 'frame'
+
+        # The model's frame w.r.t. its parent
+        #
+        # @return [Array<Float>]
+        def pose
+            Conversions.pose_to_eigen(xml.elements["pose"])
+        end
+    end
+end

--- a/lib/sdf/joint.rb
+++ b/lib/sdf/joint.rb
@@ -105,5 +105,12 @@ module SDF
             end
             return p
         end
+
+        def each_frame
+            return enum_for(__method__) if !block_given?
+            xml.elements.to_a('frame').each do |frame_xml|
+                yield(Frame.new(frame_xml, self))
+            end
+        end
     end
 end

--- a/lib/sdf/joint.rb
+++ b/lib/sdf/joint.rb
@@ -19,7 +19,7 @@ module SDF
                         end
 
                         if !@parent_link
-                            raise Invalid, "joint #{self} specifies #{name} as its parent link, but this link does not exist, existing links: #{parent.each_link.map(&:name).join(", ")}"
+                            raise Invalid, "joint #{self} specifies #{name} as its parent link, but this link does not exist, existing links: #{parent.each_link_with_name.map { |_, name| name }.join(", ")}"
                         end
                     when 'child'
                         name = child.text.strip
@@ -29,7 +29,7 @@ module SDF
                             @child_link  = parent.find_link_by_name(name)
                         end
                         if !@child_link
-                            raise Invalid, "joint #{self} specifies #{name} as its child link, but this link does not exist, existing links: #{parent.each_link.map(&:name).join(", ")}"
+                            raise Invalid, "joint #{self} specifies #{name} as its child link, but this link does not exist, existing links: #{parent.each_link_with_name.map { |_, name| name }.join(", ")}"
                         end
                     when 'sensor'
                         @sensors << Sensor.new(child, self)

--- a/lib/sdf/link.rb
+++ b/lib/sdf/link.rb
@@ -75,5 +75,12 @@ module SDF
         xml = REXML::Element.new("link")
         xml.attributes['name'] = '__world__'
         World = Link.new(xml).freeze
+
+        def each_frame
+            return enum_for(__method__) if !block_given?
+            xml.elements.to_a('frame').each do |frame_xml|
+                yield(Frame.new(frame_xml, self))
+            end
+        end
     end
 end

--- a/lib/sdf/model.rb
+++ b/lib/sdf/model.rb
@@ -63,7 +63,7 @@ module SDF
                     @frames["#{child_model.name}::#{frame_name}"] = frame
                 end
             end
-            models.merge!(submodels)
+            @models.merge!(submodels)
             joints.each do |name, joint_xml|
                 @joints[name] = Joint.new(joint_xml, self)
             end

--- a/lib/sdf/model.rb
+++ b/lib/sdf/model.rb
@@ -35,18 +35,29 @@ module SDF
             @models = models
             @links  = links
             @joints = Hash.new
+
+            submodels = Hash.new
             models.each do |child_name, child_model|
-                child_model.each_link do |link|
-                    @links["#{child_model.name}::#{link.name}"] = link
+                child_model.each_model_with_name do |m, m_name|
+                    submodels["#{child_model.name}::#{m_name}"] = m
                 end
-                child_model.each_joint do |joint|
-                    @joints["#{child_model.name}::#{joint.name}"] = joint
+                child_model.each_link_with_name do |link, link_name|
+                    @links["#{child_model.name}::#{link_name}"] = link
+                end
+                child_model.each_joint_with_name do |joint, joint_name|
+                    @joints["#{child_model.name}::#{joint_name}"] = joint
                 end
             end
+            models.merge!(submodels)
             joints.each do |name, joint_xml|
                 @joints[name] = Joint.new(joint_xml, self)
             end
             @plugins = plugins.map { |child| Plugin.new(child, self) }
+        end
+
+        # (see Element#find_by_name)
+        def find_by_name(name)
+            @models[name] || @links[name] || @joints[name]
         end
 
         # The model's pose w.r.t. its parent
@@ -67,16 +78,38 @@ module SDF
 
         # Enumerates this model's submodels
         #
-        # @yieldparam [Link] link
-        def each_model(&block)
-            @models.each_value(&block)
+        # The enumeration is recursive, i.e. it will yield models-of-submodels
+        #
+        # @yieldparam [Model] model
+        def each_model
+            return enum_for(__method__) if !block_given?
+            @models.each_value { |m| yield(m) }
+        end
+
+        # Enumerates this model's submodels along with their relative name
+        #
+        # @yieldparam [Model] model
+        # @yieldparam [String] name the name, relative to self
+        def each_model_with_name
+            return enum_for(__method__) if !block_given?
+            @models.each { |name, m| yield(m, name) }
         end
 
         # Enumerates this model's links
         #
         # @yieldparam [Link] link
-        def each_link(&block)
-            @links.each_value(&block)
+        def each_link
+            return enum_for(__method__) if !block_given?
+            @links.each_value { |l| yield(l) }
+        end
+
+        # Enumerates this model's links with their relative names
+        #
+        # @yieldparam [Link] link
+        # @yieldparam [String] name the name, relative to self
+        def each_link_with_name
+            return enum_for(__method__) if !block_given?
+            @links.each { |name, link| yield(link, name) }
         end
 
         # Resolves a link by its name
@@ -90,7 +123,17 @@ module SDF
         #
         # @yieldparam [Joint] joint
         def each_joint(&block)
-            @joints.each_value(&block)
+            return enum_for(__method__) if !block_given?
+            @joints.each_value { |j| yield(j) }
+        end
+
+        # Enumerates this model's joints along with their relative names
+        #
+        # @yieldparam [Joint] joint
+        # @yieldparam [String] name the name, relative to self
+        def each_joint_with_name
+            return enum_for(__method__) if !block_given?
+            @joints.each { |name, j| yield(j, name) }
         end
 
         # Resolves a joint by its name

--- a/lib/sdf/physics.rb
+++ b/lib/sdf/physics.rb
@@ -49,16 +49,6 @@ module SDF
                 1.0 / rate
             end
         end
-
-        # The world's update rate in realtime, in Hz, if specified
-        #
-        # @return [Integer,nil]
-        # @see update_period
-        def real_time_update_rate
-            if real_time_update_rate = xml.elements['real_time_update_rate']
-                Integer(real_time_update_rate.text)
-            end
-        end
     end
 end
 

--- a/lib/sdf/root.rb
+++ b/lib/sdf/root.rb
@@ -68,7 +68,7 @@ module SDF
             return enum_for(__method__, recursive: recursive) if !block_given?
 
             xml.elements.each do |element|
-                if element.name == 'world'
+                if element.name == 'world' && recursive
                     World.new(element, self).each_model(&block)
                 elsif element.name == 'model'
                     yield(Model.new(element, self))

--- a/lib/sdf/root.rb
+++ b/lib/sdf/root.rb
@@ -75,6 +75,8 @@ module SDF
         def find_all_included_models(model, sdf_version = version)
             if uri_match = /^model:\/\//.match(model)
                 full_path = XML.model_path_from_name(uri_match.post_match, sdf_version: sdf_version)
+            else
+                full_path = model
             end
             (@metadata['includes'][full_path] || Array.new).map do |full_name|
                 if element = find_by_name(full_name)

--- a/lib/sdf/root.rb
+++ b/lib/sdf/root.rb
@@ -61,6 +61,30 @@ module SDF
             end
         end
 
+        # Returns Model objects from a given included model
+        #
+        # The included model can be a full path to a SDF file or a model:// URI.
+        # This function will not work - and raise - on flattened SDF trees.
+        #
+        # @param [String] model the model, either as a full path to the SDF
+        #   file, or as a model:// URI
+        # @return [Array] list of included models (as Model objects) in this
+        #   root that are coming from the requested model
+        # @raise ArgumentError if an expected node cannot be found. This will
+        #   happen on flattened SDF trees.
+        def find_all_included_models(model, sdf_version = version)
+            if uri_match = /^model:\/\//.match(model)
+                full_path = XML.model_path_from_name(uri_match.post_match, sdf_version: sdf_version)
+            end
+            (@metadata['includes'][full_path] || Array.new).map do |full_name|
+                if element = find_by_name(full_name)
+                    element
+                else
+                    raise ArgumentError, "#{full_name}, referred to as an included element for #{full_path} does not seem to exist, is this a flattened SDF tree ?"
+                end
+            end
+        end
+
         # Enumerates the toplevel models
         #
         # @yieldparam [Model] model

--- a/lib/sdf/root.rb
+++ b/lib/sdf/root.rb
@@ -8,6 +8,14 @@ module SDF
         # @return [REXML::Document]
         attr_reader :xml
 
+        # The metadata produced while loading this root
+        attr_reader :metadata
+
+        def initialize(xml, metadata = Hash.new)
+            super(xml)
+            @metadata = metadata
+        end
+
         # Loads a SDF file
         #
         # @param [String] sdf_file the path to the SDF file or a model:// URI
@@ -19,11 +27,12 @@ module SDF
         # @raise [XML::NotSDF] if the file is not a SDF file
         # @raise [XML::InvalidXML] if the file is not a valid XML file
         # @return [Root]
-        def self.load(sdf_file, expected_sdf_version = nil)
+        def self.load(sdf_file, expected_sdf_version = nil, flatten: true)
             if sdf_file =~ /^model:\/\/(.*)/
-                return load_from_model_name($1, expected_sdf_version)
+                return load_from_model_name($1, expected_sdf_version, flatten: flatten)
             else
-                new(XML.load_sdf(sdf_file).root)
+                xml, metadata = XML.load_sdf(sdf_file, flatten: flatten, metadata: true)
+                new(xml.root, metadata)
             end
         end
 
@@ -37,8 +46,9 @@ module SDF
         #   (as version * 100, i.e. version 1.5 is represented by 150). Leave to
         #   nil to always read the latest.
         # @return [Root]
-        def self.load_from_model_name(model_name, sdf_version = nil)
-            new(XML.model_from_name(model_name, sdf_version).root)
+        def self.load_from_model_name(model_name, sdf_version = nil, flatten: true)
+            xml, metadata = XML.model_from_name(model_name, sdf_version, flatten: flatten, metadata: true)
+            new(xml.root, metadata)
         end
 
         # The SDF version

--- a/lib/sdf/sensor.rb
+++ b/lib/sdf/sensor.rb
@@ -46,7 +46,7 @@ module SDF
         # @see update_period
         def update_rate
             if update_rate = xml.elements['update_rate']
-                Integer(update_rate.text)
+                Float(update_rate.text)
             end
         end
     end

--- a/lib/sdf/world.rb
+++ b/lib/sdf/world.rb
@@ -38,6 +38,16 @@ module SDF
         def spherical_coordinates
             child_by_name('spherical_coordinates', SphericalCoordinates)
         end
+
+        # Enumerate the world-level plugins
+        def each_plugin
+            return enum_for(__method__) if !block_given?
+            xml.elements.each do |element|
+                if element.name == 'plugin'
+                    yield(Plugin.new(element, self))
+                end
+            end
+        end
     end
 end
 

--- a/lib/sdf/xml.rb
+++ b/lib/sdf/xml.rb
@@ -280,6 +280,9 @@ module SDF
                     raise InvalidXML, "no uri element in include"
                 elsif uri =~ /^model:\/\/(\w+)(?:\/(.*))?/
                     model_name, file_name = $1, $2
+                    if file_name
+                        raise ArgumentError, "does not know how to resolve an explicit file in a model:// URI inside an include"
+                    end
                     included_sdf, included_metadata =
                         model_from_name(model_name, sdf_version, metadata: true, flatten: false)
                 elsif File.directory?(uri_path = File.expand_path(uri, base_path))

--- a/lib/sdf/xml.rb
+++ b/lib/sdf/xml.rb
@@ -17,7 +17,13 @@ module SDF
         class InvalidXML < ArgumentError; end
         # Exception raised when trying to resolve a model that cannot be found
         # in {model_path}
-        class NoSuchModel < ArgumentError; end
+        class NoSuchModel < ArgumentError
+            attr_reader :model_name
+
+            def initialize(model_name)
+                @model_name = model_name
+            end
+        end
 
         # The search path for models
         #
@@ -162,7 +168,7 @@ module SDF
                     return cache.path
                 end
             end
-            raise NoSuchModel, "cannot find model #{model_name} in path #{model_path.join(":")}. You probably want to update the GAZEBO_MODEL_PATH environment variable, or set SDF.model_path explicitely"
+            raise NoSuchModel.new(model_name), "cannot find model #{model_name} in path #{model_path.join(":")}. You probably want to update the GAZEBO_MODEL_PATH environment variable, or set SDF.model_path explicitely"
         end
 
         # Load a model by its name

--- a/lib/sdf/xml.rb
+++ b/lib/sdf/xml.rb
@@ -252,7 +252,7 @@ module SDF
 
             replacements = []
             elem.elements.each do |inc|
-                if inc.name == 'model' # model-within-model
+                if inc.name == 'world' || inc.name == 'model' # model-within-model
                     added_includes = add_include_tags(inc, sdf_version, base_path)
                     includes.merge! added_includes do |_, old, new|
                         old + new
@@ -326,7 +326,7 @@ module SDF
                 parent << model
             end
 
-            if elem.name == 'model'
+            if elem.name != 'sdf'
                 prefix = "#{elem.attributes['name']}::"
                 includes.each do |uri, paths|
                     paths.map! { |p| "#{prefix}#{p}" }
@@ -392,13 +392,9 @@ module SDF
             sdf_version = sdf_version_of(sdf)
             
             sdf_metadata = Hash['includes' => Hash.new, 'path' => sdf_file]
-            sdf.root.elements.each do |element|
-                if element.name == 'world' || element.name == 'model'
-                    includes = add_include_tags(element, sdf_version, File.dirname(sdf_file))
-                    sdf_metadata['includes'].merge!(includes) do |_, old, new|
-                        old + new
-                    end
-                end
+            includes = add_include_tags(sdf.root, sdf_version, File.dirname(sdf_file))
+            sdf_metadata['includes'].merge!(includes) do |_, old, new|
+                old + new
             end
             resolve_relative_uris(sdf.root, sdf_version, File.dirname(sdf_file))
 

--- a/test/data/invalid_models/include_with_specific_file_in_uri/model.config
+++ b/test/data/invalid_models/include_with_specific_file_in_uri/model.config
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<model>
+  <name>simple_model</name>
+  <sdf version="1.5">model.sdf</sdf>
+</model>

--- a/test/data/invalid_models/include_with_specific_file_in_uri/model.sdf
+++ b/test/data/invalid_models/include_with_specific_file_in_uri/model.sdf
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+    <model name="simple test model">
+        <include>
+            <uri>model://test/model.sdf</uri>
+        </include>
+    </model>
+</sdf>

--- a/test/data/models/include_directly_under_root/model.sdf
+++ b/test/data/models/include_directly_under_root/model.sdf
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+    <include>
+        <uri>model://simple_model</uri>
+        <name>root_model</name>
+    </include>
+</sdf>

--- a/test/data/models/includes_at_each_level/model.config
+++ b/test/data/models/includes_at_each_level/model.config
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<model>
+  <name>simple_model</name>
+  <sdf version="1.5">model.sdf</sdf>
+</model>

--- a/test/data/models/model_with_includes/model.sdf
+++ b/test/data/models/model_with_includes/model.sdf
@@ -1,8 +1,6 @@
 <?xml version="1.0" ?>
 <sdf version="1.5">
-    <world>
-        <include>
-            <uri>model://simple_model</uri>
-        </include>
-    </world>
+    <include>
+        <uri>model://simple_model</uri>
+    </include>
 </sdf>

--- a/test/test_element.rb
+++ b/test/test_element.rb
@@ -31,6 +31,16 @@ module SDF
                 elp = Element.new(el1.xml.elements.first, el1)
                 assert_equal '0::1::p', elp.full_name
             end
+
+            it "stops at the provided root if given" do
+                xml = REXML::Document.new("<root><e name=\"0\"><e name=\"1\"><e name=\"p\" /></e></e></root>")
+                # This is because all SDF elements have a name except the root
+                el0 = Element.new(xml.root.elements.first)
+                el1 = Element.new(el0.xml.elements.first, el0)
+                elp = Element.new(el1.xml.elements.first, el1)
+                assert_equal 'p', elp.full_name(root: el1)
+                assert_equal '1::p', elp.full_name(root: el0)
+            end
         end
 
         describe "#child_by_name" do

--- a/test/test_element.rb
+++ b/test/test_element.rb
@@ -22,6 +22,17 @@ module SDF
                     root
             end
 
+            it "is changed if the element's name is modified" do
+                xml = REXML::Document.new("<a name=\"a\"><e name=\"p\" /></a>")
+                element = Element.new(xml.root)
+                child   = Element.new(xml.root.elements.first, element)
+                assert_equal 'a::p', child.full_name
+                child.name = "child"
+                assert_equal 'a::child', child.full_name
+                element.name = "parent"
+                assert_equal 'parent::child', child.full_name
+            end
+
             it "returns the name if there is no parent" do
                 xml = REXML::Document.new("<e name=\"p\" />")
                 element = Element.new(xml.root)

--- a/test/test_element.rb
+++ b/test/test_element.rb
@@ -169,7 +169,7 @@ module SDF
             it "deep-copies the XML tree" do
                 link = @new_root.each_model.first.each_link.first
                 link.xml.attributes['name'] = 'deep_copy_test'
-                assert_equal 'l', @root.each_model.first.each_link.first.name
+                assert_equal 'l', @root.each_world.first.each_model.first.each_link.first.name
             end
             it "ignores a root without a version" do
                 assert_nil @new_root.version

--- a/test/test_joint.rb
+++ b/test/test_joint.rb
@@ -128,6 +128,18 @@ module SDF
                 assert Eigen::Quaternion.Identity.approx?(t.rotation)
             end
         end
+
+        describe "#each_frame" do
+            it "enumerates its frames" do
+                xml = REXML::Document.new(<<-EOXML).root
+                <joint><frame name="test0" /><frame name="test1" /></joint>
+                EOXML
+                joint = Joint.new(xml)
+                frames = joint.each_frame.to_a
+                assert_equal ['test0', 'test1'], frames.map(&:name)
+                assert_equal joint, frames.first.parent
+            end
+        end
     end
 end
 

--- a/test/test_link.rb
+++ b/test/test_link.rb
@@ -60,5 +60,17 @@ module SDF
                 assert !Link.new(xml).kinematic?
             end
         end
+
+        describe "#each_frame" do
+            it "enumerates its frames" do
+                xml = REXML::Document.new(<<-EOXML).root
+                <link><frame name="test0" /><frame name="test1" /></link>
+                EOXML
+                link = Link.new(xml)
+                frames = link.each_frame.to_a
+                assert_equal ['test0', 'test1'], frames.map(&:name)
+                assert_equal link, frames.first.parent
+            end
+        end
     end
 end

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -215,6 +215,34 @@ describe SDF::Model do
         end
     end
 
+    describe "model enumeration" do
+        it "enumerates the models" do
+            xml = REXML::Document.new(<<-EOXML).root
+            <model>
+              <model name="test0" />
+              <model name="test1" />
+            </model>
+            EOXML
+            model = SDF::Model.new(xml)
+            assert_equal ['test0', 'test1'], model.each_model.map(&:name)
+        end
+
+        it "enumerates its children model's models" do
+            xml = REXML::Document.new(<<-EOXML).root
+            <model>
+              <model name="test0">
+                <model name="test1">
+                  <model name="test2" />
+                </model>
+              </model>
+            </model>
+            EOXML
+            model = SDF::Model.new(xml)
+            assert_equal [['test0', 'test0'], ['test1', 'test0::test1'], ['test2', 'test0::test1::test2']],
+                model.each_model_with_name.map { |model, name| [model.name, name] }
+        end
+    end
+
     describe "link enumeration" do
         it "enumerates the links" do
             xml = REXML::Document.new(<<-EOXML).root

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -189,5 +189,32 @@ describe SDF::Model do
             assert Eigen::Quaternion.from_angle_axis(2, Eigen::Vector3.UnitZ).approx?(p.rotation)
         end
     end
+
+    describe "frame enumeration" do
+        it "enumerates the frames" do
+            xml = REXML::Document.new(<<-EOXML).root
+            <model>
+              <frame name="test0" />
+              <frame name="test1" />
+            </model>
+            EOXML
+            model = SDF::Model.new(xml)
+            assert_equal ['test0', 'test1'], model.each_frame.map(&:name)
+        end
+
+        it "enumerates its children model's frames" do
+            xml = REXML::Document.new(<<-EOXML).root
+            <model>
+              <model name="sub">
+              <frame name="test0" />
+              <frame name="test1" />
+              </model>
+            </model>
+            EOXML
+            model = SDF::Model.new(xml)
+            assert_equal [['test0', 'sub::test0'], ['test1', 'sub::test1']],
+                model.each_frame_with_name.map { |frame, name| [frame.name, name] }
+        end
+    end
 end
 

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -207,6 +207,26 @@ describe SDF::Model do
             subm = model.each_model.first
             assert_equal model.canonical_link, subm.canonical_link
         end
+        it "returns the parent's model canonical link for submodels, even if the submodel has a link" do
+            xml = REXML::Document.new('<model><link name="l" /><model name="sub"><link name="subl" /></model></model>').root
+            model = SDF::Model.new(xml)
+            subm = model.each_model.first
+            assert_equal model.canonical_link, subm.canonical_link
+        end
+        it "uses the submodel's canonical link if it has no link of its own" do
+            xml = REXML::Document.new('<model><model name="sub"><link name="l" /></model></model>').root
+            model = SDF::Model.new(xml)
+            subm = model.each_model.first
+            assert_equal subm.each_link.first, model.canonical_link
+        end
+        it "uses the second submodel's canonical link if it has no link of its own and the first doesn't have a link either" do
+            xml = REXML::Document.new('<model><model name="first" /><model name="sub"><link name="l" /></model></model>').root
+            model = SDF::Model.new(xml)
+            submodels = model.each_model.to_a
+            expected = submodels[1].canonical_link
+            assert_equal expected, submodels[0].canonical_link
+            assert_equal expected, model.canonical_link
+        end
         it "returns its first link if the parent model has no canonical link" do
             xml = REXML::Document.new('<model><model name="sub"><link name="l" /></model></model>').root
             model = SDF::Model.new(xml)

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -190,6 +190,36 @@ describe SDF::Model do
         end
     end
 
+    describe "link enumeration" do
+        it "enumerates the links" do
+            xml = REXML::Document.new(<<-EOXML).root
+            <model>
+              <link name="test0" />
+              <link name="test1" />
+            </model>
+            EOXML
+            model = SDF::Model.new(xml)
+            assert_equal ['test0', 'test1'], model.each_link.map(&:name)
+        end
+
+        it "enumerates its children model's links" do
+            xml = REXML::Document.new(<<-EOXML).root
+            <model>
+              <link name="test0" />
+              <model name="sub">
+                <link name="test1" />
+                <model name="subsub">
+                  <link name="test2" />
+                </model>
+              </model>
+            </model>
+            EOXML
+            model = SDF::Model.new(xml)
+            assert_equal [['test0', 'test0'], ['test1', 'sub::test1'], ['test2', 'sub::subsub::test2']],
+                model.each_link_with_name.map { |link, name| [link.name, name] }
+        end
+    end
+
     describe "frame enumeration" do
         it "enumerates the frames" do
             xml = REXML::Document.new(<<-EOXML).root

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -190,6 +190,31 @@ describe SDF::Model do
         end
     end
 
+    describe "the canonical link" do
+        it "is nil if the model has no link" do
+            xml = REXML::Document.new("<model />").root
+            model = SDF::Model.new(xml)
+            refute model.canonical_link
+        end
+        it "returns the first link at its level for root models" do
+            xml = REXML::Document.new('<model><link name="l" /></model>').root
+            model = SDF::Model.new(xml)
+            assert_equal 'l', model.canonical_link.name
+        end
+        it "returns the parent's model canonical link for submodels, if it has one" do
+            xml = REXML::Document.new('<model><link name="l" /><model name="sub" /></model>').root
+            model = SDF::Model.new(xml)
+            subm = model.each_model.first
+            assert_equal model.canonical_link, subm.canonical_link
+        end
+        it "returns its first link if the parent model has no canonical link" do
+            xml = REXML::Document.new('<model><model name="sub"><link name="l" /></model></model>').root
+            model = SDF::Model.new(xml)
+            subm = model.each_model.first
+            assert_equal subm.each_link.first, subm.canonical_link
+        end
+    end
+
     describe "link enumeration" do
         it "enumerates the links" do
             xml = REXML::Document.new(<<-EOXML).root

--- a/test/test_root.rb
+++ b/test/test_root.rb
@@ -59,7 +59,7 @@ describe SDF::XML do
             root.each_model do |m|
                 model_names << m.name
             end
-            assert_equal(['simple test model'], model_names.sort)
+            assert_equal ['simple test model'], model_names
         end
         it "calls load_from_model_name if given a URI" do
             version = flexmock

--- a/test/test_root.rb
+++ b/test/test_root.rb
@@ -63,7 +63,7 @@ describe SDF::XML do
         end
         it "calls load_from_model_name if given a URI" do
             version = flexmock
-            flexmock(SDF::Root).should_receive(:load_from_model_name).once.with('model_in_uri', version).and_return(obj = flexmock)
+            flexmock(SDF::Root).should_receive(:load_from_model_name).once.with('model_in_uri', version, Hash).and_return(obj = flexmock)
             assert_equal obj, SDF::Root.load('model://model_in_uri', version)
         end
     end

--- a/test/test_root.rb
+++ b/test/test_root.rb
@@ -68,6 +68,22 @@ describe SDF::XML do
         end
     end
 
+    describe "#find_all_included_models" do
+        it "returns the Model objects of the loaded models" do
+            root = SDF::Root.load_from_model_name('includes_at_each_level', flatten: false)
+            models = root.find_all_included_models('model://simple_model').map(&:full_name)
+
+            expected = [
+                'w::child_of_world',
+                'w::model::child_of_model',
+                'w::model::model_in_model::child_of_model_in_model',
+                'root_model::child_of_root_model',
+                'root_model::model_in_root_model::child_of_model_in_root_model'
+            ]
+            assert_equal expected, models
+        end
+    end
+
     describe "each_world" do
         it "does not yield anything if no worlds are defined" do
             root = SDF::Root.new(REXML::Document.new("<sdf></sdf>").root)

--- a/test/test_root.rb
+++ b/test/test_root.rb
@@ -82,6 +82,21 @@ describe SDF::XML do
             ]
             assert_equal expected, models
         end
+
+        it "handles a full path" do
+            full_path = SDF::XML.model_path_from_name('simple_model')
+            root = SDF::Root.load_from_model_name('includes_at_each_level', flatten: false)
+            models = root.find_all_included_models(full_path).map(&:full_name)
+
+            expected = [
+                'w::child_of_world',
+                'w::model::child_of_model',
+                'w::model::model_in_model::child_of_model_in_model',
+                'root_model::child_of_root_model',
+                'root_model::model_in_root_model::child_of_model_in_root_model'
+            ]
+            assert_equal expected, models
+        end
     end
 
     describe "each_world" do

--- a/test/test_sensor.rb
+++ b/test/test_sensor.rb
@@ -3,12 +3,11 @@ require 'sdf/test'
 module SDF
     describe Sensor do
         describe "#update_rate" do
-            it "returns the rate as integer" do
-                xml = REXML::Document.new("<sensor><update_rate>22</update_rate></sensor>").root
+            it "returns the rate as float" do
+                xml = REXML::Document.new("<sensor><update_rate>22.1</update_rate></sensor>").root
                 sensor = Sensor.new(xml)
                 p = sensor.update_rate
-                assert p.integer?
-                assert_equal 22, p
+                assert_in_delta 22.1, p, 1e-9
             end
             it "returns nil if the rate is not defined" do
                 xml = REXML::Document.new("<sensor/>").root
@@ -19,9 +18,9 @@ module SDF
 
         describe "#update_period" do
             it "returns the period in seconds" do
-                xml = REXML::Document.new("<sensor><update_rate>22</update_rate></sensor>").root
+                xml = REXML::Document.new("<sensor><update_rate>22.1</update_rate></sensor>").root
                 sensor = Sensor.new(xml)
-                assert_in_delta (1.0/22.0), sensor.update_period, 1e-6
+                assert_in_delta (1.0/22.1), sensor.update_period, 1e-6
             end
             it "returns nil if the rate is not defined" do
                 xml = REXML::Document.new("<sensor/>").root

--- a/test/test_spherical_coordinates.rb
+++ b/test/test_spherical_coordinates.rb
@@ -131,8 +131,8 @@ module SDF
                 refute utm.north?
 
                 utm = coord.utm(north: true)
-                assert_in_delta 490_986, utm.easting, 1
-                assert_in_delta -111, utm.northing, 1
+                assert_in_delta(490_986, utm.easting, 1)
+                assert_in_delta(-111, utm.northing, 1)
                 assert utm.north?
             end
         end

--- a/test/test_xml.rb
+++ b/test/test_xml.rb
@@ -164,12 +164,28 @@ describe SDF::XML do
                 end
             end
 
+            it "reports the mapping from on-disk model path to in-SDF model path in metadata" do
+                _, metadata = SDF::XML.load_sdf(
+                    File.join(models_dir, 'includes_at_each_level', 'model.sdf'),
+                    metadata: true)
+
+                expected = Hash[
+                    'model://simple_model' => [
+                        'child_of_world',
+                        'model::child_of_model',
+                        'model::model_in_model::child_of_model_in_model',
+                        'root_model::child_of_root_model',
+                        'root_model::model_in_root_model::child_of_model_in_root_model']
+                ]
+                assert_equal ['model://simple_model'], metadata['includes'].keys
+                assert_equal expected['model://simple_model'].sort, metadata['includes']['model://simple_model'].sort
+            end
+
             describe "a toplevel model include" do
                 it "adds the included model as child of a toplevel world element" do
                     sdf = SDF::XML.load_sdf(File.join(models_dir, 'includes_at_each_level', 'model.sdf'))
                     assert sdf.elements["/sdf/world/model[@name='child_of_world']"]
                 end
-
                 it "injects the include/pose element in the included tree" do
                     sdf = SDF::XML.load_sdf(File.join(models_dir, "model_with_new_pose_in_include", "model.sdf"))
                     model = sdf.elements.enum_for(:each, 'sdf/world/model/pose').first

--- a/test/test_xml.rb
+++ b/test/test_xml.rb
@@ -184,6 +184,11 @@ describe SDF::XML do
                     metadata['includes'][model_full_path].sort
             end
 
+            it "handles a include tag directly under root" do
+                sdf = SDF::XML.load_sdf(File.join(models_dir, 'include_directly_under_root', 'model.sdf'))
+                assert sdf.elements["/sdf/model[@name='root_model']"]
+            end
+
             describe "a toplevel model include" do
                 it "adds the included model as child of a toplevel world element" do
                     sdf = SDF::XML.load_sdf(File.join(models_dir, 'includes_at_each_level', 'model.sdf'))

--- a/test/test_xml.rb
+++ b/test/test_xml.rb
@@ -377,5 +377,176 @@ describe SDF::XML do
             assert_equal "gazebo model in #{File.join(models_dir, 'versioned_model')} does not offer a SDF file matching version 100", exception.message
         end
     end
+
+    describe "flatten_model_tree" do
+        def flatten_model_tree(xml)
+            xml = SDF::XML.deep_copy_xml(xml)
+            SDF::XML.flatten_model_tree(xml)
+            xml
+        end
+
+        it "does not touch a root model" do
+            xml = load_xml(<<-EOXML)
+            <sdf><model name="root">
+            <pose>0 1 2 3 4 5</pose>
+            <link name="link" />
+            </model></sdf>
+            EOXML
+            assert_xml_identical xml, flatten_model_tree(xml)
+        end
+        it "moves elements from the submodel to the parent" do
+            expected = load_xml(<<-EOXML)
+            <sdf><model name="root">
+            <link name="link" />
+            <some_element />
+            </model></sdf>
+            EOXML
+            xml = load_xml(<<-EOXML)
+            <sdf><model name="root">
+            <model name="submodel"><some_element /></model>
+            <link name="link" />
+            </model></sdf>
+            EOXML
+            assert_xml_identical expected, flatten_model_tree(xml)
+        end
+        it "namespaces the element names" do
+            expected = load_xml(<<-EOXML)
+            <sdf><model name="root">
+            <link name="link" />
+            <some_element name="submodel::test" />
+            </model></sdf>
+            EOXML
+            xml = load_xml(<<-EOXML)
+            <sdf><model name="root">
+            <model name="submodel"><some_element name="test" /></model>
+            <link name="link" />
+            </model></sdf>
+            EOXML
+            assert_xml_identical expected, flatten_model_tree(xml)
+        end
+        it "namespaces a joints parent and child link names" do
+            expected = load_xml(<<-EOXML)
+            <sdf><model name="root">
+            <link name="submodel::root" />
+            <link name="submodel::child" />
+            <joint name="submodel::test">
+            <parent>submodel::root</parent>
+            <child>submodel::child</child>
+            </joint>
+            </model></sdf>
+            EOXML
+            xml = load_xml(<<-EOXML)
+            <sdf><model name="root">
+            <model name="submodel">
+            <link name="root" />
+            <link name="child" />
+            <joint name="test">
+            <parent>root</parent>
+            <child>child</child>
+            </joint>
+            </model>
+            </model></sdf>
+            EOXML
+            assert_xml_identical expected, flatten_model_tree(xml)
+        end
+        it "transforms a frame element using the submodel's pose" do
+            xml = load_xml(<<-EOXML)
+            <sdf>
+            <model name="root"><pose>1 2 3 0 0 0.1</pose>
+            <model name="submodel"><pose>2 3 4 0 0 0</pose>
+            <frame name="f"><pose>3 4 5 0 0 0</pose></frame>
+            </model>
+            </model>
+            </sdf>
+            EOXML
+            xml = flatten_model_tree(xml)
+            frame = SDF::Frame.new(xml.elements['model/frame'])
+            assert_approx_equals Eigen::Vector3.new(5, 7, 9), frame.pose.translation
+            assert_approx_equals Eigen::Quaternion.Identity, frame.pose.rotation
+        end
+        it "transforms a link element using the submodel's pose" do
+            xml = load_xml(<<-EOXML)
+            <sdf>
+            <model name="root"><pose>1 2 3 0 0 0.1</pose>
+            <model name="submodel"><pose>2 3 4 0 0 0</pose>
+            <link name="f"><pose>3 4 5 0 0 0</pose></link>
+            </model>
+            </model>
+            </sdf>
+            EOXML
+            xml = flatten_model_tree(xml)
+            frame = SDF::Link.new(xml.elements['model/link'])
+            assert_approx_equals Eigen::Vector3.new(5, 7, 9), frame.pose.translation
+            assert_approx_equals Eigen::Quaternion.Identity, frame.pose.rotation
+        end
+        it "transforms a joint element using the submodel's pose" do
+            xml = load_xml(<<-EOXML)
+            <sdf>
+            <model name="root"><pose>1 2 3 0 0 0.1</pose>
+            <model name="submodel"><pose>2 3 4 0 0 0</pose>
+            <joint name="f"><pose>3 4 5 0 0 0</pose></joint>
+            </model>
+            </model>
+            </sdf>
+            EOXML
+            xml = flatten_model_tree(xml)
+            joint = SDF::Joint.new(xml.elements['model/joint'])
+            assert_approx_equals Eigen::Vector3.new(5, 7, 9), joint.pose.translation
+            assert_approx_equals Eigen::Quaternion.Identity, joint.pose.rotation
+        end
+        it "does not transform a joint's axis pose using the submodel's pose if it has use_parent_model_frame unset" do
+            xml = load_xml(<<-EOXML)
+            <sdf>
+            <model name="root"><pose>1 2 3 0 0 0.1</pose>
+            <model name="submodel"><pose>2 3 4 0 0 0</pose>
+            <joint name="f">
+                <pose>3 4 5 0 0 0</pose>
+                <axis><xyz>0 1 2</xyz></axis>
+            </joint>
+            </model>
+            </model>
+            </sdf>
+            EOXML
+            xml = flatten_model_tree(xml)
+            axis = SDF::Axis.new(xml.elements['model/joint/axis'])
+            assert_approx_equals Eigen::Vector3.new(0, 1, 2), axis.xyz
+        end
+        it "rotates a joint's axis pose using the submodel's pose if it has use_parent_model_frame set" do
+            xml = load_xml(<<-EOXML)
+            <sdf>
+            <model name="root"><pose>1 2 3 0 0 0.1</pose>
+            <model name="submodel"><pose>2 3 4 0 0 0.2</pose>
+            <joint name="f">
+                <pose>3 4 5 0 0 0</pose>
+                <axis><xyz>0 1 2</xyz><use_parent_model_frame>true</use_parent_model_frame></axis>
+            </joint>
+            </model>
+            </model>
+            </sdf>
+            EOXML
+            xml = flatten_model_tree(xml)
+            axis = SDF::Axis.new(xml.elements['model/joint/axis'])
+            assert_approx_equals (Eigen::Quaternion.from_angle_axis(0.2, Eigen::Vector3.UnitZ) * Eigen::Vector3.new(0, 1, 2)), axis.xyz
+        end
+    end
+
+    def load_xml(string)
+        REXML::Document.new(string).root
+    end
+
+    def assert_xml_identical(expected, actual)
+        normalized = Class.new(REXML::Formatters::Pretty) do
+            def write_text(node, output)
+                super(node.to_s.strip, output)
+            end
+        end
+
+        normalized.new(indentation=0,ie_hack=false).
+            write(expected, expected_normalized = '')
+        normalized.new(indentation=0,ie_hack=false).
+            write(actual, actual_normalized = '')
+
+        assert_equal expected_normalized, actual_normalized
+    end
 end
 

--- a/test/test_xml.rb
+++ b/test/test_xml.rb
@@ -52,7 +52,7 @@ describe SDF::XML do
     describe "gazebo_models" do
         it "loads all models available in the path" do
             models = SDF::XML.gazebo_models
-            assert_equal 22, models.size
+            assert_equal 23, models.size
 
             assert(sdf = models['simple_model'])
             model = sdf.elements.enum_for(:each, 'sdf/model').first

--- a/test/test_xml.rb
+++ b/test/test_xml.rb
@@ -359,7 +359,8 @@ describe SDF::XML do
             exception = assert_raises(SDF::XML::NoSuchModel) do
                 SDF::XML.model_from_name('does_not_exist')
             end
-            assert_match /cannot find model does_not_exist in path .*. You probably want to update the GAZEBO_MODEL_PATH environment variable, or set SDF.model_path explicitely/, exception.message
+            expected = /cannot find model does_not_exist in path .*. You probably want to update the GAZEBO_MODEL_PATH environment variable, or set SDF.model_path explicitely/
+            assert_match expected, exception.message
         end
         it "raises if the model can be found, but not for the expected version" do
             exception = assert_raises(SDF::XML::UnavailableSDFVersionInModel) do

--- a/test/test_xml.rb
+++ b/test/test_xml.rb
@@ -113,6 +113,14 @@ describe SDF::XML do
                     assert_equal "while loading #{full_path}: no uri element in include",
                         exception.message
                 end
+                it "raises if it the URI refers to a specific file" do
+                    full_path = File.join(invalid_models_dir, "include_with_specific_file_in_uri", "model.sdf")
+                    exception = assert_raises(ArgumentError) do
+                        SDF::XML.load_sdf(full_path)
+                    end
+                    assert_equal "while loading #{full_path}: does not know how to resolve an explicit file in a model:// URI inside an include",
+                        exception.message
+                end
                 it "raises if it finds an unexpected element as child of the 'include' path" do
                     full_path = File.join(invalid_models_dir, "include_with_invalid_element", "model.sdf")
                     exception = assert_raises(SDF::XML::InvalidXML) do

--- a/test/test_xml.rb
+++ b/test/test_xml.rb
@@ -169,16 +169,19 @@ describe SDF::XML do
                     File.join(models_dir, 'includes_at_each_level', 'model.sdf'),
                     metadata: true)
 
-                expected = Hash[
-                    'model://simple_model' => [
-                        'child_of_world',
-                        'model::child_of_model',
-                        'model::model_in_model::child_of_model_in_model',
-                        'root_model::child_of_root_model',
-                        'root_model::model_in_root_model::child_of_model_in_root_model']
+                model_full_path = File.expand_path(File.join(
+                    'data', 'models', 'simple_model', 'model.sdf'), __dir__)
+                expected = [
+                    'w::child_of_world',
+                    'w::model::child_of_model',
+                    'w::model::model_in_model::child_of_model_in_model',
+                    'root_model::child_of_root_model',
+                    'root_model::model_in_root_model::child_of_model_in_root_model'
                 ]
-                assert_equal ['model://simple_model'], metadata['includes'].keys
-                assert_equal expected['model://simple_model'].sort, metadata['includes']['model://simple_model'].sort
+
+                assert_equal [model_full_path], metadata['includes'].keys
+                assert_equal expected.sort,
+                    metadata['includes'][model_full_path].sort
             end
 
             describe "a toplevel model include" do
@@ -228,7 +231,7 @@ describe SDF::XML do
                 end
                 it "processes it if the parent model is itself child of another model that is child of a world" do
                     sdf = sdf_includes_at_each_level
-                    assert sdf.elements["/sdf/world/model/model[@name='model_in_model']/link[@name='child_of_model_in_model::link']"]
+                    assert sdf.elements["/sdf/world/model[@name='model']/link[@name='model_in_model::child_of_model_in_model::link']"]
                 end
                 it "processes it if the parent model is toplevel" do
                     sdf = sdf_includes_at_each_level
@@ -236,7 +239,7 @@ describe SDF::XML do
                 end
                 it "processes it if the parent model is itself child of a toplevel model" do
                     sdf = sdf_includes_at_each_level
-                    assert sdf.elements["/sdf/model[@name='root_model']/model[@name='model_in_root_model']/link[@name='child_of_model_in_root_model::link']"]
+                    assert sdf.elements["/sdf/model[@name='root_model']/link[@name='model_in_root_model::child_of_model_in_root_model::link']"]
                 end
 
                 it "namespaces a joints parent link" do
@@ -335,8 +338,8 @@ describe SDF::XML do
             assert_equal('versioned model 1.3', model.attributes['name'])
         end
         it "caches the result" do
-            sdf1 = SDF::XML.model_from_name('simple_model')
-            sdf2 = SDF::XML.model_from_name('simple_model')
+            sdf1 = SDF::XML.model_from_name('simple_model', flatten: false)
+            sdf2 = SDF::XML.model_from_name('simple_model', flatten: false)
             assert_same sdf1, sdf2
         end
         it "caches the result in a version-aware way" do


### PR DESCRIPTION
This changes the previously implemented support for models in models. What was there before is that *if* a model is **included** in another through an `include` tag, the included model would be flattened in its parent, e.g.:

~~~
<model ...>
   <include><name>test</name></include>
</model>
~~~

would become (assuming that the included model has a `root` link)

~~~
<model ...>
   <link name="test::root" />
</model>
~~~

This is nice for support libraries like `kdl_parser`, as they don't have to know about the model-in-model structure. However, it makes semantic analysis of the SDF difficult (one can't know where a sub-model is easily) and it is inconsistent w.r.t a model being explicitely added as a child of another (instead of included).

This PR keeps the flattening default behavior, but flattens all models (included or not). Optionally, it can also return a non-flattened structure, and allows to find where a given model is included in it.