### PR TITLE
xml: fix included paths resolution when models are included in models

### DIFF
--- a/lib/sdf/xml.rb
+++ b/lib/sdf/xml.rb
@@ -42,15 +42,15 @@ module SDF
             @model_path = Array(path)
             clear_cache
         end
-        
+
         #load model_path with default parameters
         def self.initialize
             @model_path = (ENV['GAZEBO_MODEL_PATH'] || '').split(':')
             @model_path << File.join(Dir.home, '.gazebo', 'models')
         end
-        
+
         initialize
-        
+
         # Clears the model cache
         #
         # @return [void]
@@ -72,8 +72,8 @@ module SDF
         def self.load_gazebo_model(dir, sdf_version = nil, metadata: false, flatten: true)
             return load_sdf(model_path_of(dir, sdf_version), metadata: metadata, flatten:  flatten)
         end
-        
-        
+
+
         # Find model string into model.config path
         #
         # @param [String] dir the path to the model directory
@@ -84,7 +84,7 @@ module SDF
         # @raise [UnavailableSDFVersionInModel] if the model does not contain a
         #   SDF file for the required SDF version
         #
-        # @return [String]        
+        # @return [String]
         def self.model_path_of(dir, sdf_version = nil)
             model_config_path = File.join(dir, "model.config")
             config = File.open(model_config_path) do |io|
@@ -301,10 +301,6 @@ module SDF
                 includes[included_metadata['path']] << name
 
                 added_includes = included_metadata['includes']
-                prefix = "#{inc.attributes['name']}::"
-                added_includes.each do |_, sdf_node_paths|
-                    sdf_node_paths.map! { |p| "#{prefix}#{p}" }
-                end
                 includes.merge!(added_includes) do |_, old, new|
                     old + new
                 end
@@ -316,7 +312,7 @@ module SDF
 
                 replacements << [inc, included_elements.first, name, overrides]
             end
-                            
+
             replacements.each do |inc, model, name, overrides|
                 parent = inc.parent
                 inc.remove
@@ -371,7 +367,7 @@ module SDF
             end
             sdf
         end
-        
+
         # Get sdf_version
         #
         # @param [REXML::Element] sdf element
@@ -398,7 +394,7 @@ module SDF
         def self.load_sdf(sdf_file, flatten: true, metadata: false)
             sdf = load_sdf_raw(sdf_file)
             sdf_version = sdf_version_of(sdf)
-            
+
             sdf_metadata = Hash['includes' => Hash.new, 'path' => sdf_file]
             includes = add_include_tags(sdf.root, sdf_version, File.dirname(sdf_file))
             sdf_metadata['includes'].merge!(includes) do |_, old, new|

--- a/test/data/regressions/dual_ur10.world
+++ b/test/data/regressions/dual_ur10.world
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+    <world name="empty_world">
+        <model name="dual_ur10_fixed">
+            <include>
+                <name>dual_ur10</name>
+                <uri>model://dual_ur10</uri>
+            </include>
+            <joint name="attached_to_ground" type="fixed">
+                <parent>world</parent>
+                <child>dual_ur10::base</child>
+            </joint>
+        </model>
+    </world>
+</sdf>

--- a/test/data/regressions/dual_ur10/model.config
+++ b/test/data/regressions/dual_ur10/model.config
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<model>
+<name>Two-UR10 system from "Building Robots with Rock and Syskit"</name>
+<sdf>model.sdf</sdf>
+<version>1.0</version>
+</model>

--- a/test/data/regressions/dual_ur10/model.sdf
+++ b/test/data/regressions/dual_ur10/model.sdf
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+    <model name="dual_ur10">
+        <link name="base" />
+        <include>
+            <name>left_arm</name>
+            <pose>0 -0.3 0 0 0 0</pose>
+            <uri>model://ur10</uri>
+        </include>
+        <joint name="left_attached_to_base" type="fixed">
+            <parent>base</parent>
+            <child>left_arm::base</child>
+        </joint>
+        <include>
+            <name>right_arm</name>
+            <pose>0 0.3 0 0 0 0</pose>
+            <uri>model://ur10</uri>
+        </include>
+        <joint name="right_attached_to_base" type="fixed">
+            <parent>base</parent>
+            <child>right_arm::base</child>
+        </joint>
+    </model>
+</sdf>

--- a/test/data/regressions/ur10/model.config
+++ b/test/data/regressions/ur10/model.config
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Universal Robotics UR10 robot arm</name>
+  <version>1.0.2</version>
+  <sdf>ur10.sdf</sdf>
+
+  <author>
+    <name>Kelsey Hawkins</name>
+    <email>kphawkins@gatech.edu</email>
+  </author>
+
+  <description>
+    The UR10 robot arm model built by Kelsey Hawkins.
+    Taken from git@github.com:ros-industrial/universal_robot.git for Gazebo testing and integration purposes.
+  </description>
+</model>

--- a/test/data/regressions/ur10/ur10.sdf
+++ b/test/data/regressions/ur10/ur10.sdf
@@ -1,0 +1,6 @@
+<?xml version='1.0'?>
+<sdf version='1.5'>
+    <model name='ur10'>
+      <link name='base' />
+    </model>
+</sdf>

--- a/test/test_xml.rb
+++ b/test/test_xml.rb
@@ -4,6 +4,9 @@ describe SDF::XML do
     def models_dir
         File.join(File.dirname(__FILE__), 'data', 'models')
     end
+    def regressions_dir
+        File.join(File.dirname(__FILE__), 'data', 'regressions')
+    end
     def invalid_models_dir
         File.join(File.dirname(__FILE__), 'data', 'invalid_models')
     end
@@ -190,6 +193,26 @@ describe SDF::XML do
                 assert_equal [model_full_path], metadata['includes'].keys
                 assert_equal expected.sort,
                     metadata['includes'][model_full_path].sort
+            end
+
+            it "properly resolves multi-level includes" do
+                SDF::XML.model_path = [regressions_dir]
+                _, metadata = SDF::XML.load_sdf(
+                    File.join(regressions_dir, 'dual_ur10.world'),
+                    metadata: true)
+
+                ur10_full_path = File.expand_path(File.join(
+                    'data', 'regressions', 'ur10', 'ur10.sdf'), __dir__)
+                dual_ur10_full_path = File.expand_path(File.join(
+                    'data', 'regressions', 'dual_ur10', 'model.sdf'), __dir__)
+                expected = Hash[
+                    ur10_full_path => %w[
+                        empty_world::dual_ur10_fixed::dual_ur10::left_arm
+                        empty_world::dual_ur10_fixed::dual_ur10::right_arm],
+                    dual_ur10_full_path => %w[empty_world::dual_ur10_fixed::dual_ur10]
+                ]
+
+                assert_equal expected, metadata['includes']
             end
 
             it "handles a include tag directly under root" do
@@ -548,4 +571,3 @@ describe SDF::XML do
         assert_equal expected_normalized, actual_normalized
     end
 end
-


### PR DESCRIPTION
This happened only on a double-inclusion, i.e. when the world would
include a model, which also included another model.

When this happened, the path to the model root would include a `::::`
in the loaded metadata, which would then fail to resolve (obviously)