### PR TITLE
memoize the spherical_coordinates element

### DIFF
--- a/lib/sdf/world.rb
+++ b/lib/sdf/world.rb
@@ -36,7 +36,9 @@ module SDF
         # @return [SphericalCoordinates]
         # @raise Invalid if there is no such element in the SDF
         def spherical_coordinates
-            child_by_name('spherical_coordinates', SphericalCoordinates)
+            @spherical_coordinates ||= child_by_name(
+                'spherical_coordinates', SphericalCoordinates
+            )
         end
 
         # Enumerate the world-level plugins


### PR DESCRIPTION
If one has to repeatedly do local-to-global coordinate conversions
(which is often the case), this is a huge performance boost.