### PR TITLE
chore: create each_direct_link as a workaround for links being discovered recursively

### DIFF
--- a/lib/sdf/model.rb
+++ b/lib/sdf/model.rb
@@ -184,7 +184,7 @@ module SDF
             @plugins.each(&block)
         end
 
-        # Enumerates this model's links
+        # Enumerates this model's direct links(does not include submodel's links)
         #
         # @yieldparam [Link] link
         def each_direct_link(&block)
@@ -193,7 +193,8 @@ module SDF
             @direct_links.each_value(&block)
         end
 
-        # Enumerates the sensors contained in this model
+        # Enumerates the sensors contained in this model(does not include submodel's
+        # sensors)
         #
         # Note that sensors are children of links and joints, i.e. calling
         # #parent on the yield sensor objects will not return self

--- a/lib/sdf/model.rb
+++ b/lib/sdf/model.rb
@@ -43,8 +43,8 @@ module SDF
                     frames[child.attributes["name"]] = Frame.new(child, self)
                 end
             end
-            @links  = links
-            @direct_links  = direct_links
+            @links = links
+            @direct_links = direct_links
             @frames = frames
             @joints = {}
             @models = {}

--- a/lib/sdf/model.rb
+++ b/lib/sdf/model.rb
@@ -23,6 +23,7 @@ module SDF
 
             models = {}
             links = {}
+            direct_links = {}
             joints = {}
             plugins = []
             frames = {}
@@ -33,6 +34,7 @@ module SDF
                     link = Link.new(child, self)
                     @canonical_link ||= link
                     links[child.attributes["name"]] = link
+                    direct_links[child.attributes["name"]] = link
                 elsif child.name == "joint"
                     joints[child.attributes["name"]] = child
                 elsif child.name == "plugin"
@@ -42,6 +44,7 @@ module SDF
                 end
             end
             @links  = links
+            @direct_links  = direct_links
             @frames = frames
             @joints = {}
             @models = {}
@@ -179,6 +182,29 @@ module SDF
         # @yieldparam [Plugin] plugin
         def each_plugin(&block)
             @plugins.each(&block)
+        end
+
+        # Enumerates this model's links
+        #
+        # @yieldparam [Link] link
+        def each_direct_link(&block)
+            return enum_for(__method__) unless block_given?
+
+            @direct_links.each_value(&block)
+        end
+
+        # Enumerates the sensors contained in this model
+        #
+        # Note that sensors are children of links and joints, i.e. calling
+        # #parent on the yield sensor objects will not return self
+        #
+        # @yieldparam [Sensor] sensor
+        def each_direct_sensor(&block)
+            return enum_for(__method__) unless block_given?
+
+            each_direct_link do |l|
+                l.each_sensor(&block)
+            end
         end
 
         # Enumerates the sensors contained in this model

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -105,7 +105,8 @@ describe SDF::Model do
         it "does not yields the submodel's links" do
             root = SDF::Model.new(
                 REXML::Document.new(
-                    "<model name=\"a\"><model name=\"b\"><link name=\"0\" /><link name=\"1\" /></model></model>"
+                    "<model name=\"a\"><model name=\"b\"><link name=\"0\" />" \
+                    "<link name=\"1\" /></model></model>"
                 ).root
             )
 
@@ -115,7 +116,8 @@ describe SDF::Model do
         it "yields the direct links" do
             root = SDF::Model.new(
                 REXML::Document.new(
-                    "<model name=\"a\"><link name=\"0\" /><link name=\"1\" /><model name=\"b\"></model></model>"
+                    "<model name=\"a\"><link name=\"0\" /><link name=\"1\" />" \
+                    "<model name=\"b\"></model></model>"
                 ).root
             )
 
@@ -137,8 +139,8 @@ describe SDF::Model do
         it "yields the links sensor otherwise" do
             root = SDF::Model.new(
                 REXML::Document.new(
-                    "<model><link name=\"0\"><sensor name=\"a\"/></link><link name=\"1\">" \
-                    "<sensor name=\"b\" /></link></model>"
+                    "<model><link name=\"0\"><sensor name=\"a\"/></link>" \
+                    "<link name=\"1\"><sensor name=\"b\" /></link></model>"
                 ).root
             )
 
@@ -146,7 +148,9 @@ describe SDF::Model do
             assert_equal 2, sensors.size
             sensors.each do |s|
                 assert_kind_of SDF::Sensor, s
-                assert_equal root.xml.elements.to_a("link/sensor[@name=\"#{s.name}\"]"), [s.xml]
+                assert_equal(
+                    root.xml.elements.to_a("link/sensor[@name=\"#{s.name}\"]"), [s.xml]
+                )
             end
         end
     end
@@ -159,7 +163,9 @@ describe SDF::Model do
         it "does not yields the submodel's sensors" do
             root = SDF::Model.new(
                 REXML::Document.new(
-                    "<model name=\"a\"><model name=\"b\"><link name=\"0\"><sensor name=\"a\"/></link><link name=\"1\"><sensor name=\"b\"/></link></model></model>"
+                    "<model name=\"a\"><model name=\"b\"><link name=\"0\">" \
+                    "<sensor name=\"a\"/></link><link name=\"1\"><sensor name=\"b\"/>" \
+                    "</link></model></model>"
                 ).root
             )
 
@@ -169,7 +175,9 @@ describe SDF::Model do
         it "yields the direct sensors" do
             root = SDF::Model.new(
                 REXML::Document.new(
-                    "<model name=\"a\"><link name=\"0\"><sensor name=\"a\"/></link><link name=\"1\"><sensor name=\"b\"/></link><model name=\"b\"></model></model>"
+                    "<model name=\"a\"><link name=\"0\"><sensor name=\"a\"/></link>" \
+                    "<link name=\"1\"><sensor name=\"b\"/></link><model name=\"b\">" \
+                    "</model></model>"
                 ).root
             )
 
@@ -177,7 +185,9 @@ describe SDF::Model do
             assert_equal 2, sensors.size
             sensors.each do |s|
                 assert_kind_of SDF::Sensor, s
-                assert_equal root.xml.elements.to_a("link/sensor[@name=\"#{s.name}\"]"), [s.xml]
+                assert_equal(
+                    root.xml.elements.to_a("link/sensor[@name=\"#{s.name}\"]"), [s.xml]
+                )
             end
         end
     end

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -97,6 +97,91 @@ describe SDF::Model do
         end
     end
 
+    describe "#each_direct_link" do
+        it "does not yield anything if the model has no link" do
+            root = SDF::Model.new(REXML::Document.new("<model></model>").root)
+            assert root.enum_for(:each_direct_link).to_a.empty?
+        end
+        it "does not yields the submodel's links" do
+            root = SDF::Model.new(
+                REXML::Document.new(
+                    "<model name=\"a\"><model name=\"b\"><link name=\"0\" /><link name=\"1\" /></model></model>"
+                ).root
+            )
+
+            links = root.enum_for(:each_direct_link).to_a
+            assert_equal 0, links.size
+        end
+        it "yields the direct links" do
+            root = SDF::Model.new(
+                REXML::Document.new(
+                    "<model name=\"a\"><link name=\"0\" /><link name=\"1\" /><model name=\"b\"></model></model>"
+                ).root
+            )
+
+            links = root.enum_for(:each_direct_link).to_a
+            assert_equal 2, links.size
+            links.each do |l|
+                assert_kind_of SDF::Link, l
+                assert_same root, l.parent
+                assert_equal root.xml.elements.to_a("link[@name=\"#{l.name}\"]"), [l.xml]
+            end
+        end
+    end
+
+    describe "#each_sensor" do
+        it "does not yield anything if the model has no sensor link" do
+            root = SDF::Model.new(REXML::Document.new("<model></model>").root)
+            assert root.enum_for(:each_sensor).to_a.empty?
+        end
+        it "yields the links sensor otherwise" do
+            root = SDF::Model.new(
+                REXML::Document.new(
+                    "<model><link name=\"0\"><sensor name=\"a\"/></link><link name=\"1\">" \
+                    "<sensor name=\"b\" /></link></model>"
+                ).root
+            )
+
+            sensors = root.enum_for(:each_sensor).to_a
+            assert_equal 2, sensors.size
+            sensors.each do |s|
+                assert_kind_of SDF::Sensor, s
+                assert_equal root.xml.elements.to_a("link/sensor[@name=\"#{s.name}\"]"), [s.xml]
+            end
+        end
+    end
+
+    describe "#each_direct_sensor" do
+        it "does not yield anything if the model has no link" do
+            root = SDF::Model.new(REXML::Document.new("<model></model>").root)
+            assert root.enum_for(:each_direct_link).to_a.empty?
+        end
+        it "does not yields the submodel's sensors" do
+            root = SDF::Model.new(
+                REXML::Document.new(
+                    "<model name=\"a\"><model name=\"b\"><link name=\"0\"><sensor name=\"a\"/></link><link name=\"1\"><sensor name=\"b\"/></link></model></model>"
+                ).root
+            )
+
+            sensors = root.enum_for(:each_direct_sensor).to_a
+            assert_equal 0, sensors.size
+        end
+        it "yields the direct sensors" do
+            root = SDF::Model.new(
+                REXML::Document.new(
+                    "<model name=\"a\"><link name=\"0\"><sensor name=\"a\"/></link><link name=\"1\"><sensor name=\"b\"/></link><model name=\"b\"></model></model>"
+                ).root
+            )
+
+            sensors = root.enum_for(:each_direct_sensor).to_a
+            assert_equal 2, sensors.size
+            sensors.each do |s|
+                assert_kind_of SDF::Sensor, s
+                assert_equal root.xml.elements.to_a("link/sensor[@name=\"#{s.name}\"]"), [s.xml]
+            end
+        end
+    end
+
     describe "#each_joint" do
         it "does not yield anything if the model has no joint" do
             root = SDF::Model.new(REXML::Document.new("<model></model>").root)


### PR DESCRIPTION
This is a temporary fix to allow the usage of sensors that are located in submodels. Soon there should be a final solution that fully removes recursivity of links and joints from models, and implements it where it is used and needed.