### PR TITLE
fix: keep consistent behaviour with empty XML document and REXML 3.4.3

### DIFF
--- a/lib/sdf/xml.rb
+++ b/lib/sdf/xml.rb
@@ -362,7 +362,11 @@ module SDF
             sdf = File.open(sdf_file) do |io|
                 REXML::Document.new(io)
             rescue REXML::ParseException => e
-                raise InvalidXML, "cannot load #{sdf_file}: #{e.message}"
+                unless e.message.match?(/No root/)
+                    raise InvalidXML, "cannot load #{sdf_file}: #{e.message}"
+                end
+
+                REXML::Document.new
             end
 
             unless sdf.root


### PR DESCRIPTION
The new rexml version is rejecting XML documents with no root elements - previously they were accepted.

Catch this to still raise NotSDF instead of the rexml exception