### PR TITLE
feat: adjust plugins to match other elements

### DIFF
--- a/lib/sdf/model.rb
+++ b/lib/sdf/model.rb
@@ -271,5 +271,14 @@ module SDF
         def each_frame(&block)
             @frames.each_value(&block)
         end
+
+        # Enumerates this model's direct frame(does not include submodel's frame)
+        #
+        # @yieldparam [Frame] frame
+        def each_direct_frame(&block)
+            return enum_for(__method__) unless block_given?
+
+            @direct_frames.each_value(&block)
+        end
     end
 end

--- a/lib/sdf/model.rb
+++ b/lib/sdf/model.rb
@@ -28,7 +28,9 @@ module SDF
             direct_frames = {}
             xml.elements.each do |child|
                 if child.name == "model"
-                    direct_models[child.attributes["name"]] = child
+                    model = Model.new(child, self)
+                    @canonical_link ||= model.canonical_link
+                    direct_models[child.attributes["name"]] = model
                 elsif child.name == "link"
                     link = Link.new(child, self)
                     @canonical_link ||= link
@@ -47,17 +49,13 @@ module SDF
             @links = direct_links.dup
             @plugins = direct_plugins.dup
             @frames = direct_frames.dup
+            @models = direct_models.dup
             @direct_links = direct_links
             @direct_plugins = direct_plugins
             @direct_frames = direct_frames
-            @direct_models = direct_models.transform_values do |xml|
-                model = Model.new(xml, self)
-                @canonical_link ||= model.canonical_link
-                model
-            end
+            @direct_models = direct_models
 
             @joints = {}
-            @models = @direct_models.dup
 
             @direct_models.each do |_child_name, child_model|
                 child_model.each_model_with_name do |m, m_name|

--- a/lib/sdf/model.rb
+++ b/lib/sdf/model.rb
@@ -25,6 +25,7 @@ module SDF
             links = {}
             direct_links = {}
             joints = {}
+            direct_joints = {}
             plugins = {}
             direct_plugins = {}
             frames = {}
@@ -38,6 +39,7 @@ module SDF
                     direct_links[child.attributes["name"]] = link
                 elsif child.name == "joint"
                     joints[child.attributes["name"]] = child
+                    direct_joints[child.attributes["name"]] = child
                 elsif child.name == "plugin"
                     plugin = Plugin.new(child, self)
                     plugins[child.attributes["name"]] = plugin
@@ -46,12 +48,14 @@ module SDF
                     frames[child.attributes["name"]] = Frame.new(child, self)
                 end
             end
+
             @links = links
             @plugins = plugins
             @direct_links = direct_links
             @direct_plugins = direct_plugins
             @frames = frames
             @joints = {}
+            @direct_joints = {}
             @models = {}
             models.each do |model_name, xml|
                 model = Model.new(xml, self)
@@ -84,6 +88,9 @@ module SDF
             end
             joints.each do |name, joint_xml|
                 @joints[name] = Joint.new(joint_xml, self)
+            end
+            direct_joints.each do |name, joint_xml|
+                @direct_joints[name] = Joint.new(joint_xml, self)
             end
         end
 
@@ -201,6 +208,15 @@ module SDF
             return enum_for(__method__) unless block_given?
 
             @plugins.each { |name, plugin| yield(plugin, name) }
+        end
+
+        # Enumerates this model's direct joints(does not include submodel's plugins)
+        #
+        # @yieldparam [joints] joints
+        def each_direct_joint(&block)
+            return enum_for(__method__) unless block_given?
+
+            @direct_joints.each_value(&block)
         end
 
         # Enumerates this model's direct plugin(does not include submodel's plugins)

--- a/lib/sdf/model.rb
+++ b/lib/sdf/model.rb
@@ -57,7 +57,7 @@ module SDF
             end
 
             @joints = {}
-            @models = {}
+            @models = @direct_models.dup
 
             @direct_models.each do |_child_name, child_model|
                 child_model.each_model_with_name do |m, m_name|
@@ -77,7 +77,6 @@ module SDF
                 end
             end
 
-            @models.merge!(@direct_models)
             @models.each_value do |m|
                 m.canonical_link = @canonical_link
             end

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -79,6 +79,46 @@ describe SDF::Model do
         end
     end
 
+    describe "#each_direct_model" do
+        it "does not yield anything if the model has no models" do
+            root = SDF::Model.new(REXML::Document.new("<model></model>").root)
+            assert root.enum_for(:each_direct_model).to_a.empty?
+        end
+
+        it "does not yields the submodel's submodels" do
+            root = SDF::Model.new(
+                REXML::Document.new(
+                    "<model name=\"a\"><model name=\"b\"><model name=\"c\">" \
+                    "</model></model></model>"
+                ).root
+            )
+
+            submodels = root.enum_for(:each_direct_model).to_a
+            assert_equal 1, submodels.size
+            submodels.each do |m|
+                assert_kind_of SDF::Model, m
+                assert_same root, m.parent
+                assert_equal root.xml.elements.to_a("model[@name=\"#{m.name}\"]"), [m.xml]
+            end
+        end
+        it "yields multiple direct submodels" do
+            root = SDF::Model.new(
+                REXML::Document.new(
+                    "<model name=\"a\"><model name=\"b\"><model name=\"c\">" \
+                    "</model><model name=\"d\"></model></model></model>"
+                ).root
+            )
+
+            submodels = root.enum_for(:each_direct_model).to_a
+            assert_equal 1, submodels.size
+            submodels.each do |m|
+                assert_kind_of SDF::Model, m
+                assert_same root, m.parent
+                assert_equal root.xml.elements.to_a("model[@name=\"#{m.name}\"]"), [m.xml]
+            end
+        end
+    end
+
     describe "#each_link" do
         it "does not yield anything if the model has no link" do
             root = SDF::Model.new(REXML::Document.new("<model></model>").root)

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -515,4 +515,37 @@ describe SDF::Model do
                          end)
         end
     end
+
+    describe "#each_direct_frame" do
+        it "does not yield anything if the model has no frame" do
+            root = SDF::Model.new(REXML::Document.new("<model></model>").root)
+            assert root.enum_for(:each_direct_frame).to_a.empty?
+        end
+
+        it "doesnt yield the submodel's frame" do
+            root = SDF::Model.new(
+                REXML::Document.new(
+                "<model name='a'><model name='b'><frame name=\"0\"/><frame name=\"1\"/>"\
+                "</model></model>").root)
+
+
+            frames = root.enum_for(:each_direct_frame).to_a
+            assert_equal 0, frames.size
+        end
+
+        it "yields the frames otherwise" do
+            root = SDF::Model.new(
+                REXML::Document.new(
+                "<model name='a'><frame name=\"0\"/><frame name=\"1\"/>"\
+                "<model name='b'></model></model>").root)
+
+            frames = root.enum_for(:each_direct_frame).to_a
+            assert_equal 2, frames.size
+            frames.each do |l|
+                assert_kind_of SDF::Frame, l
+                assert_same root, l.parent
+                assert_equal root.xml.elements.to_a("frame[@name=\"#{l.name}\"]"), [l.xml]
+            end
+        end
+    end
 end

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -304,7 +304,7 @@ describe SDF::Model do
             assert root.enum_for(:each_direct_joint).to_a.empty?
         end
 
-        it "yields the joints no indirect joints" do
+        it "doesnt yield the submodel's joints" do
             root = SDF::Model.new(
                 REXML::Document.new(
                 "<model name='a'><model name='b'><link name='parent' /><link name='child' />"\

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -347,11 +347,12 @@ describe SDF::Model do
         it "doesnt yield the submodel's joints" do
             root = SDF::Model.new(
                 REXML::Document.new(
-                "<model name='a'><model name='b'><link name='parent' /><link name='child' />"\
-                "<joint name=\"0\"><parent>parent</parent><child>child</child></joint>"\
-                "<joint name=\"1\"><parent>parent</parent><child>child</child>/></joint>"\
-                "</model></model>").root)
-
+                    "<model name='a'><model name='b'><link name='parent' />" \
+                    "<link name='child' /><joint name=\"0\"><parent>parent</parent><child>" \
+                    "child</child></joint><joint name=\"1\"><parent>parent</parent>" \
+                    "<child>child</child>/></joint></model></model>"
+                ).root
+            )
 
             joints = root.enum_for(:each_direct_joint).to_a
             assert_equal 0, joints.size
@@ -360,10 +361,12 @@ describe SDF::Model do
         it "yields the joints otherwise" do
             root = SDF::Model.new(
                 REXML::Document.new(
-                "<model name='a'><link name='parent' /><link name='child' />"\
-                "<joint name=\"0\"><parent>parent</parent><child>child</child></joint>"\
-                "<joint name=\"1\"><parent>parent</parent><child>child</child>/></joint>"\
-                "<model name='b'></model></model>").root)
+                    "<model name='a'><link name='parent' /><link name='child' />" \
+                    "<joint name=\"0\"><parent>parent</parent><child>child</child></joint>" \
+                    "<joint name=\"1\"><parent>parent</parent><child>child</child>/>" \
+                    "</joint><model name='b'></model></model>"
+                ).root
+            )
 
             joints = root.enum_for(:each_direct_joint).to_a
             assert_equal 2, joints.size
@@ -565,9 +568,10 @@ describe SDF::Model do
         it "doesnt yield the submodel's frame" do
             root = SDF::Model.new(
                 REXML::Document.new(
-                "<model name='a'><model name='b'><frame name=\"0\"/><frame name=\"1\"/>"\
-                "</model></model>").root)
-
+                    "<model name='a'><model name='b'><frame name=\"0\"/>" \
+                    "<frame name=\"1\"/></model></model>"
+                ).root
+            )
 
             frames = root.enum_for(:each_direct_frame).to_a
             assert_equal 0, frames.size
@@ -576,8 +580,10 @@ describe SDF::Model do
         it "yields the frames otherwise" do
             root = SDF::Model.new(
                 REXML::Document.new(
-                "<model name='a'><frame name=\"0\"/><frame name=\"1\"/>"\
-                "<model name='b'></model></model>").root)
+                    "<model name='a'><frame name=\"0\"/><frame name=\"1\"/>" \
+                    "<model name='b'></model></model>"
+                ).root
+            )
 
             frames = root.enum_for(:each_direct_frame).to_a
             assert_equal 2, frames.size


### PR DESCRIPTION
This will also allow the usage of the flag
RockGazebo::Syskit.scope_device_name_with_links_and_submodels to fix the plugins being defined at every level of the model hierarchy instead of only at the last one