### PR TITLE
fix: link returned by canonical_link in submodels

### DIFF
--- a/lib/sdf/model.rb
+++ b/lib/sdf/model.rb
@@ -76,7 +76,7 @@ module SDF
             end
 
             @models.each_value do |m|
-                m.canonical_link = @canonical_link
+                m.canonical_link ||= @canonical_link
             end
             @direct_joints = direct_joints.transform_values do |joint_xml|
                 Joint.new(joint_xml, self)

--- a/lib/sdf/xml.rb
+++ b/lib/sdf/xml.rb
@@ -60,6 +60,20 @@ module SDF
 
         # Load the SDF from a gazebo model
         #
+        # ruby_sdformat supports two modes to load a SDF model. If `flatten` is false,
+        # the XML returned keeps the whole model hierarchy, and for instance a Model
+        # can have a Model as child. If `flatten` is true, the same processing that
+        # is done by gazebo is applied. `<include>` actually takes the content of
+        # the included model and inserts it in the including model. This requires
+        # prefixing names from the included model by the model name itself (e.g.
+        # `imu` becomes `includedmodelname::imu`), and also some other transformations
+        # regarding poses. This is all done automatically
+        #
+        # Given that plugins can't be processed automatically, the transformation
+        # also adds a new 'scope' attribute to plugin elements so that the plugin
+        # code can internally do this transformation. The scope is the full name
+        # of the element containing the plugin
+        #
         # @param [String] dir the path to the model directory
         # @!macro sdf_version
         # @raise [Errno::ENOENT] if the files does not exist
@@ -398,7 +412,38 @@ module SDF
         # Unlike {.load_sdf_raw}, this resolves the include tags in the XML
         # representation
         #
+        # ## Flatten
+        #
+        # ruby_sdformat supports two modes to load a SDF model. If `flatten` is false,
+        # the XML returned keeps the whole model hierarchy, and for instance a Model
+        # can have a Model as child. If `flatten` is true, the same processing that
+        # is done by gazebo is applied. `<include>` actually takes the content of
+        # the included model and inserts it in the including model. This requires
+        # prefixing names from the included model by the model name itself (e.g.
+        # `imu` becomes `includedmodelname::imu`), and also some other transformations
+        # regarding poses. This is all done automatically
+        #
+        # Given that plugins can't be processed automatically, the transformation
+        # also adds a new 'scope' attribute to plugin elements so that the plugin
+        # code can internally do this transformation. The scope is the full name
+        # of the element containing the plugin
+        #
+        # ## Metadata
+        #
+        # The 'metadata' flag instructs the function to return a metadata hash in
+        # adddition to the XML tree. This hash contains an 'includes' entry which
+        # is a list of [uri, path] pairs, where `uri` is the URI of the model that
+        # has been included and `path` the gazebo path (of the form `a::b::c`) in
+        # the generated XML tree where `uri` was inserted
+        #
         # @param [String] sdf_file the path to the SDF file
+        # @param [Boolean] flatten flattens the XML model or not (see above)
+        # @param [Boolean] metadata whether the method should return a metadata hash
+        #   about the various inclusions that have been performed. See above for
+        #   the hash format
+        # @return [REXML::Element,(REXML::Element,Hash)] either the XML tree by itself
+        #   if `metadata` is false, or the pair of the tree and the metadata hash
+        #   otherwise.
         # @raise [Errno::ENOENT] if the files does not exist
         # @raise [NotSDF] if the file is not a SDF file
         # @raise [InvalidXML] if the file is not a valid XML file
@@ -461,6 +506,18 @@ module SDF
             end
         end
 
+        # Applies the name and pose mappings necessary to resolve model inclusion
+        #
+        # ruby_sdformat supports two loading modes
+        # the usage of SDF models to describe the robots kinematic chains and
+        # sensors. This requires using the hierarchical structure of `include` tags
+        # instead of "flattening" it as gazebo expects. Among the things that need
+        # transforming are all the references to other objects (e.g. a link name
+        # needs to be scoped according to the flattened hierarchy)
+        #
+        # This process is done by ruby_sdformat for all
+        #
+        # While ruby_sdformat does the work
         def self.transform_submodel_nodes(submodel, basename)
             new = []
             model_pose = nil

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -442,11 +442,13 @@ describe SDF::Model do
             subm = model.each_model.first
             assert_equal model.canonical_link, subm.canonical_link
         end
-        it "returns the parent's model canonical link for submodels, even if the submodel has a link" do
-            xml = REXML::Document.new('<model><link name="l" /><model name="sub"><link name="subl" /></model></model>').root
+        it "returns the first submodel link, even if the parent has a link" do
+            xml = REXML::Document.new(
+                '<model><link name="parent_l" /><model name="sub"><link name="sub_l" /></model></model>'
+            ).root
             model = SDF::Model.new(xml)
             subm = model.each_model.first
-            assert_equal model.canonical_link, subm.canonical_link
+            assert_equal subm.each_link.first, subm.canonical_link
         end
         it "uses the submodel's canonical link if it has no link of its own" do
             xml = REXML::Document.new('<model><model name="sub"><link name="l" /></model></model>').root


### PR DESCRIPTION
It was (on purpose) returning the canonical link of the root model. But that makes it unstable when we start including models.

De-facto, gazebo has no notion of "included models". Make instead the canonical link of a model the first link of said model.