### PR TITLE
chore: make the overall API a little bit more uniform

### DIFF
--- a/lib/sdf/element.rb
+++ b/lib/sdf/element.rb
@@ -93,7 +93,8 @@ module SDF
                 "model" => Model,
                 "sdf" => Root,
                 "link" => Link,
-                "joint" => Joint]
+                "joint" => Joint,
+                "plugin" => Plugin]
 
             if (klass = xml_to_class[xml.name])
                 return klass.new(xml, parent)

--- a/lib/sdf/model.rb
+++ b/lib/sdf/model.rb
@@ -87,6 +87,10 @@ module SDF
         # The link that is used to represent the pose of the model itself
         attr_accessor :canonical_link
 
+        def find_model_by_name(name)
+            @models[name]
+        end
+
         # (see Element#find_by_name)
         def find_by_name(name)
             @models[name] || @links[name] || @joints[name]

--- a/lib/sdf/sensor.rb
+++ b/lib/sdf/sensor.rb
@@ -18,6 +18,16 @@ module SDF
             @sensor_info = xml.elements[type]
         end
 
+        def each_direct_plugin(&block)
+            each_plugin(&block)
+        end
+
+        def each_plugin
+            xml.elements.each do |plugin_xml|
+                yield(Plugin.new(plugin_xml, self))
+            end
+        end
+
         # The sensor type
         def type
             xml.attributes["type"]

--- a/lib/sdf/world.rb
+++ b/lib/sdf/world.rb
@@ -16,10 +16,19 @@ module SDF
 
         xml_tag_name "world"
 
+        def find_model_by_name(name)
+            each_model.find { |m| m.name == name }
+        end
+
+        # @deprecated use {#each_direct_model} instead
+        def each_model(&block)
+            each_direct_model(&block)
+        end
+
         # Enumerates the models from this world
         #
         # @yieldparam [Model] model
-        def each_model
+        def each_direct_model
             return enum_for(__method__) unless block_given?
 
             xml.elements.each do |element|
@@ -38,8 +47,15 @@ module SDF
             )
         end
 
+        # @deprecated use {#each_direct_plugin} instead
+        def each_plugin(&block)
+            each_direct_plugin(&block)
+        end
+
         # Enumerate the world-level plugins
-        def each_plugin
+        #
+        # @yieldparam [Plugin]
+        def each_direct_plugin
             return enum_for(__method__) unless block_given?
 
             xml.elements.each do |element|

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -61,6 +61,32 @@ describe SDF::Model do
         end
     end
 
+    describe "#find_model_by_name" do
+        before do
+            xml_s = <<~XML
+                <model>
+                    <model name="0"><model name="a" /></model>
+                    <model name="1" />
+                </model>
+            XML
+            @xml = REXML::Document.new(xml_s).root
+            @root = SDF::Model.new(@xml)
+        end
+        it "returns nil if the model has no " do
+            assert_nil @root.find_model_by_name("does_not_exist")
+        end
+        it "returns a direct model" do
+            model = @root.find_model_by_name("1")
+            assert_kind_of SDF::Model, model
+            assert_equal @xml.elements["model[@name=\"1\"]"], model.xml
+        end
+        it "returns models recursively" do
+            model = @root.find_model_by_name("0::a")
+            assert_kind_of SDF::Model, model
+            assert_equal @xml.elements["//model[@name=\"a\"]"], model.xml
+        end
+    end
+
     describe "#each_model" do
         it "does not yield anything if the model has no models" do
             root = SDF::Model.new(REXML::Document.new("<model></model>").root)

--- a/test/test_sensor.rb
+++ b/test/test_sensor.rb
@@ -28,5 +28,23 @@ module SDF
                 assert_nil sensor.update_period
             end
         end
+
+        describe "#each_plugin" do
+            it "does not yield anything if the sensor has no plugin" do
+                root = SDF::Sensor.new(REXML::Document.new("<sensor />").root)
+                assert root.enum_for(:each_plugin).to_a.empty?
+            end
+            it "yields the plugins otherwise" do
+                root = SDF::Sensor.new(REXML::Document.new("<sensor><plugin name=\"0\" /><plugin name=\"1\" /></sensor>").root)
+
+                plugin = root.enum_for(:each_plugin).to_a
+                assert_equal 2, plugin.size
+                plugin.each do |l|
+                    assert_kind_of SDF::Plugin, l
+                    assert_same root, l.parent
+                    assert_equal root.xml.elements.to_a("plugin[@name=\"#{l.name}\"]"), [l.xml]
+                end
+            end
+        end
     end
 end

--- a/test/test_world.rb
+++ b/test/test_world.rb
@@ -20,6 +20,17 @@ module SDF
                 end
             end
         end
+        describe "#find_model_by_name" do
+            it "returns nil if the model does not exist" do
+                root = SDF::World.new(REXML::Document.new("<world><model name=\"0\" /><model name=\"1\" /></world>").root)
+                assert_nil root.find_model_by_name("does_not_exist")
+            end
+            it "yields the models otherwise" do
+                xml = REXML::Document.new("<world><model name=\"0\" /><model name=\"1\" /></world>").root
+                world = SDF::World.new(xml)
+                assert_equal xml.elements["model[@name=\"1\"]"], world.find_model_by_name("1").xml
+            end
+        end
         describe ".empty" do
             it "creates a world with no models" do
                 world = World.empty(name: "test")


### PR DESCRIPTION
Defined each_direct_* versions on classes that have only direct enumerators, for compatibility with Model

Created find_model_by_name on relevant classes

Added enumeration method for plugins on Sensor